### PR TITLE
Update plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.23.0</version>
+    <version>5.24.0</version>
     <relativePath />
   </parent>
 
@@ -15,11 +15,12 @@
   <version>${revision}${changelist}</version>
 
   <description>Provides jQuery 3.x for Jenkins plugins.</description>
-  <url>https://github.com/jenkinsci/jquery3-api-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <properties>
     <revision>3.6.0-3</revision>
     <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jquery.version>3.6.0</jquery.version>
 
     <module.name>${project.groupId}.jquery3</module.name>
@@ -97,9 +98,9 @@
   </build>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/jquery3-api-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/jquery3-api-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/jquery3-api-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 


### PR DESCRIPTION
I have been attempting to run PCT tests in `jenkinsci/bom` against Java 17 and newer versions of PCT, and this plugin is running into failures because its parent POM is too old. This PR updates the parent POM to the latest build toolchain from jenkinsci/analysis-pom-plugin#446 to facilitate Java 17 compatibility testing and PCT updates in `jenkinsci/bom`.