### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 def configurations = [
-  [ platform: "linux", jdk: "11" ]
+  [ platform: "linux", jdk: "21" ],
+  [ platform: "linux", jdk: "17" ]
 ]
 
 buildPlugin(failFast: false, configurations: configurations)


### PR DESCRIPTION
## Test with Java 21 

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024. We'll need to move past Java 11 by that time. It does not change the supported Java version or the byte code that is being generated.

This intentionally does not include Java 11 in the test configuration because Java 11 byte code is being generated by the Java 17 and Java 21 compilation and because Java 11 is being tested at least weekly by the plugin bill of materials.

Let's save the expense of testing Java 11 on ci.jenkins.io and rely on the existing tests (bom) of Java 11 and the Java 17 and Java 21 tests that run with Java 11 byte code.

We could also consider switching this repository to test only Java 17 as the preferred Java version for Jenkins controllers.  I'm open to either Java 17 or Java 21 + Java 17.  The actual costs of running the tests in this repository are small.

### Testing done

Confirmed tests pass with Java 21 on Linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
